### PR TITLE
[#3] Fix zero digit stored as string instead of number

### DIFF
--- a/package/lib/hook/usePasscode.ts
+++ b/package/lib/hook/usePasscode.ts
@@ -34,13 +34,12 @@ const usePasscode = (props: PasscodeProps) => {
      */
     const getEventHandlers = (index: number) => {
         const onChange = (e: BaseSyntheticEvent) => {
-            // Change the arrayValue and update only when number key is pressed
             setPasscode((preValue: (string | number)[]) => {
                 const newArray = [...preValue];
 
-                if (parseInt(e.target.value)) {
+                if (isNumeric(e.target.value)) {
                     newArray[index] = parseInt(e.target.value);
-                } else {
+                } else if (isAlphaNumeric) {
                     newArray[index] = e.target.value;
                 }
 
@@ -48,7 +47,7 @@ const usePasscode = (props: PasscodeProps) => {
             });
         };
 
-        const onFocus = (e: BaseSyntheticEvent) => {
+        const onFocus = () => {
             setCurrentFocusedIndex(index);
         };
 


### PR DESCRIPTION
## Summary

- Use `isNumeric()` instead of `parseInt()` to check for numeric input in `onChange`
- Guard non-numeric storage with `isAlphaNumeric` flag
- Remove misleading comment and unused `e` parameter from `onFocus`
- Add 4 new tests for value type consistency

## Problem

When typing "0", `parseInt("0")` returns `0` which is falsy in JavaScript, causing it to fall through to the else branch and store the value as the string `"0"` instead of the number `0`.

This resulted in inconsistent types in the passcode array: `[1, 2, "0", 4]` instead of `[1, 2, 0, 4]`.

## Solution

Use the existing `isNumeric()` utility function which correctly identifies "0" as numeric.

Also added a guard so non-numeric values are only stored when `isAlphaNumeric` mode is enabled.

## Test plan

- [x] All 11 tests pass
- [x] New tests verify zero is stored as number
- [x] New tests verify type consistency across all digits
- [x] New tests verify alphanumeric mode stores letters as strings
- [x] New tests verify numeric mode rejects non-numeric input

Fixes #3