### PR TITLE
[#8] Fix release workflow to checkout tag instead of branch

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -26,13 +26,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-            ref: release
+          ref: ${{ github.event.release.tag_name }}
       - uses: actions/setup-node@v3
         with:
           node-version: 16
           registry-url: https://npm.pkg.github.com/
       - run: yarn install --frozen-lockfile
       - run: yarn build
-      - run: yarn publish
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary

- Checkout the release tag instead of the `release` branch
- Use `npm publish` instead of `yarn publish` for CI compatibility

## Problem

The release workflow was failing because:
1. It checked out the `release` branch which contained stale code (v1.0.0)
2. `yarn publish` couldn't authenticate in CI (no interactive prompt available)

## Solution

1. Use `${{ github.event.release.tag_name }}` to checkout the exact tagged commit
2. Use `npm publish` which works with `NODE_AUTH_TOKEN` environment variable

## Follow-up

After merging, the `release` branch should be deleted as it's no longer needed.

Fixes #8