### PR TITLE
[#10] Publish to npm registry instead of GitHub Packages

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -10,29 +10,28 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 22
       - run: yarn install --frozen-lockfile
       - run: yarn test
 
-  publish-gpr:
+  publish-npm:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          node-version: 22
+          registry-url: https://registry.npmjs.org/
       - run: yarn install --frozen-lockfile
       - run: yarn build
-      - run: npm publish
+      - run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,14 @@
 name: check-unit-tests
 on: push
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - name: Install modules
-              run: yarn
-            - name: Run tests
-              run: yarn test
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Install modules
+        run: yarn install --frozen-lockfile
+      - name: Run tests
+        run: yarn test

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,1 @@
 registry=https://registry.yarnpkg.com/
-
-@farmisen:registry=https://npm.pkg.github.com
-
-

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ It is a group of input elements with each element only accepting one character. 
 
 ## Installation
 
-This package is published to GitHub Packages.
+```shell
+yarn add @farmisen/react-headless-passcode
+```
+
+Or with npm:
 
 ```shell
-# Configure npm/yarn for @farmisen scope
-echo "@farmisen:registry=https://npm.pkg.github.com" >> .npmrc
-
-# Install
-yarn add @farmisen/react-headless-passcode
+npm install @farmisen/react-headless-passcode
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "react-dom": ">=16.8.0"
   },
   "publishConfig": {
-    "@farmisen:registry": "https://npm.pkg.github.com"
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

Switch from GitHub Packages to npm public registry for easier installation.

## Changes

### Workflow Updates
- Use `registry.npmjs.org` instead of `npm.pkg.github.com`
- Use `NPM_TOKEN` secret instead of `GITHUB_TOKEN`
- Update `actions/checkout` to v6
- Update `actions/setup-node` to v6
- Update Node.js version to 22

### Package Config
- Update `publishConfig` to `{ "access": "public" }`
- Remove GitHub Packages scope from `.npmrc`

### Documentation
- Simplify installation instructions (no more `.npmrc` setup needed)

## After Merging

Clients can install with just:
```bash
yarn add @farmisen/react-headless-passcode
```

No authentication or `.npmrc` configuration needed.

## Notes

- NPM_TOKEN secret has been added to the repo
- Token expires in 90 days (npm granular token policy)

Fixes #10